### PR TITLE
Make aiosocks and bottom optional at runtime.

### DIFF
--- a/connectrum/client.py
+++ b/connectrum/client.py
@@ -88,7 +88,7 @@ class StratumClient:
                 try:
                     socks_host, socks_port = use_tor
                 except TypeError:
-                    socks_host, socks_port = 'localhost', 9150
+                    socks_host, socks_port = 'localhost', 9050
 
                 # basically no-one has .onion SSL certificates, and
                 # pointless anyway.

--- a/connectrum/svr_info.py
+++ b/connectrum/svr_info.py
@@ -1,6 +1,16 @@
 #
 # Store information about servers. Filter and select based on their protocol support, etc.
 #
+
+# Runtime check for optional modules
+from importlib import util as importutil
+
+# Check if bottom is present.
+if importutil.find_spec("bottom") is not None:
+    have_bottom = True
+else:
+    have_bottom = False
+
 import time, random, json
 from .constants import DEFAULT_PORTS
 
@@ -142,17 +152,20 @@ class KnownServers(dict):
 
             Slow; takes 30+ seconds but authoritative and current.
         '''
-        from .findall import IrcListener
+        if have_bottom:
+            from .findall import IrcListener
 
-        # connect and fetch current set of servers who are
-        # on #electrum channel at freenode
+            # connect and fetch current set of servers who are
+            # on #electrum channel at freenode
 
-        bot = IrcListener(irc_nickname=irc_nickname, irc_password=irc_password)
-        results = bot.loop.run_until_complete(bot.collect_data())
-        bot.loop.close()
+            bot = IrcListener(irc_nickname=irc_nickname, irc_password=irc_password)
+            results = bot.loop.run_until_complete(bot.collect_data())
+            bot.loop.close()
 
-        # merge by nick name
-        self.update(results)
+            # merge by nick name
+            self.update(results)
+        else:
+            return(False)
 
     def add_single(self, hostname, ports, nickname=None, **kws):
         '''

--- a/optional_requirements.txt
+++ b/optional_requirements.txt
@@ -1,0 +1,5 @@
+# for IRC poll of servers; somewhat optional?
+bottom>=1.0.2
+
+# for assess to TOR and other socks5 proxies
+aiosocks>=0.1.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,2 @@
-# for IRC poll of servers; somewhat optional?
-bottom>=1.0.2
-
-# for assess to TOR and other socks5 proxies
-aiosocks>=0.1.5
-
 # for examples/explore.py
 aiohttp


### PR DESCRIPTION
Make TOR and IRC support optional. Modules aiosocks and bottom are detected at runtime and global variables have_aiosocks and have_bottom are set to True or False. Functions requiring those modules use those global variables to continue or not.