### PR TITLE
Logging improvements

### DIFF
--- a/connectrum/client.py
+++ b/connectrum/client.py
@@ -18,7 +18,6 @@ from collections import defaultdict
 from .exc import ElectrumErrorResponse
 import logging
 
-# Obtain the logger.
 logger = logging.getLogger(__name__)
 
 class StratumClient:
@@ -266,10 +265,7 @@ if __name__ == '__main__':
     from transport import SocketTransport
     from svr_info import KnownServers, ServerInfo
 
-    #import logging
     logging.basicConfig(format="%(asctime)-11s %(message)s", datefmt="[%d/%m/%Y-%H:%M:%S]")
-    #logging.getLogger('connectrum').setLevel(logging.DEBUG)
-    #logging.getLogger('asyncio').setLevel(logging.DEBUG)
 
     loop = asyncio.get_event_loop()
     loop.set_debug(True)

--- a/connectrum/client.py
+++ b/connectrum/client.py
@@ -14,9 +14,12 @@ if importutil.find_spec("aiosocks") is not None:
 else:
     have_aiosocks = False
 
-from .utils import logger
 from collections import defaultdict
 from .exc import ElectrumErrorResponse
+import logging
+
+# Obtain the logger.
+logger = logging.getLogger(__name__)
 
 class StratumClient:
 
@@ -263,8 +266,9 @@ if __name__ == '__main__':
     from transport import SocketTransport
     from svr_info import KnownServers, ServerInfo
 
-    import logging
-    logging.getLogger('connectrum').setLevel(logging.DEBUG)
+    #import logging
+    logging.basicConfig(format="%(asctime)-11s %(message)s", datefmt="[%d/%m/%Y-%H:%M:%S]")
+    #logging.getLogger('connectrum').setLevel(logging.DEBUG)
     #logging.getLogger('asyncio').setLevel(logging.DEBUG)
 
     loop = asyncio.get_event_loop()

--- a/connectrum/findall.py
+++ b/connectrum/findall.py
@@ -2,8 +2,11 @@
 #
 #
 import bottom, random, time, asyncio
-from .utils import logger
 from .svr_info import ServerInfo
+import logging
+
+# Obtain the logger.
+logger = logging.getLogger(__name__)
 
 class IrcListener(bottom.Client):
     def __init__(self, irc_nickname=None, irc_password=None, ssl=True):

--- a/connectrum/findall.py
+++ b/connectrum/findall.py
@@ -5,7 +5,6 @@ import bottom, random, time, asyncio
 from .svr_info import ServerInfo
 import logging
 
-# Obtain the logger.
 logger = logging.getLogger(__name__)
 
 class IrcListener(bottom.Client):

--- a/connectrum/protocol.py
+++ b/connectrum/protocol.py
@@ -5,7 +5,6 @@
 import asyncio, json
 import logging
 
-# Obtain the logger.
 logger = logging.getLogger(__name__)
 
 class StratumProtocol(asyncio.Protocol):

--- a/connectrum/protocol.py
+++ b/connectrum/protocol.py
@@ -3,7 +3,10 @@
 #
 #
 import asyncio, json
-from .utils import logger
+import logging
+
+# Obtain the logger.
+logger = logging.getLogger(__name__)
 
 class StratumProtocol(asyncio.Protocol):
     client = None

--- a/connectrum/utils.py
+++ b/connectrum/utils.py
@@ -1,8 +1,0 @@
-
-
-import logging
-import logging.handlers
-
-logging.basicConfig(format="%(asctime)-11s %(message)s", datefmt="[%d/%m/%Y-%H:%M:%S]")
-logger = logging.getLogger('connectrum')
-

--- a/examples/cli.py
+++ b/examples/cli.py
@@ -65,7 +65,6 @@ def main():
     args = parser.parse_args()
 
     import logging
-    logging.getLogger('connectrum').setLevel(logging.DEBUG)
 
     # convert to our datastruct about servers.
     svr = ServerInfo(args.server, args.server,

--- a/examples/spider.py
+++ b/examples/spider.py
@@ -69,7 +69,6 @@ if __name__ == '__main__':
 
     if args.debug:
         import logging
-        logging.getLogger('connectrum').setLevel(logging.DEBUG)
 
     if args.irc:
         print("Connecting to freenode #electrum... (slow, be patient)")

--- a/examples/spider.py
+++ b/examples/spider.py
@@ -62,13 +62,8 @@ if __name__ == '__main__':
                         help='File to save resulting server list into (JSON)')
     parser.add_argument('--timeout', default=30, type=int,
                         help='Total time to take (overall)')
-    parser.add_argument('--debug', default=False, action="store_true",
-                        help='Enable debug output from connectrum library')
 
     args = parser.parse_args()
-
-    if args.debug:
-        import logging
 
     if args.irc:
         print("Connecting to freenode #electrum... (slow, be patient)")

--- a/examples/subscribe.py
+++ b/examples/subscribe.py
@@ -56,7 +56,6 @@ def main():
 
     if args.debug:
         import logging
-        logging.getLogger('connectrum').setLevel(logging.DEBUG)
 
     # convert to our datastruct about servers.
     svr = ServerInfo(args.server, args.server,

--- a/examples/subscribe.py
+++ b/examples/subscribe.py
@@ -49,13 +49,8 @@ def main():
                         help='Port number to override default for protocol')
     parser.add_argument('--tor', default=False, action="store_true",
                         help='Use local Tor proxy to connect')
-    parser.add_argument('--debug', default=False, action="store_true",
-                        help='Enable debug output from connectrum library')
 
     args = parser.parse_args()
-
-    if args.debug:
-        import logging
 
     # convert to our datastruct about servers.
     svr = ServerInfo(args.server, args.server,


### PR DESCRIPTION
The current way logging is handled causes it to block logging when programs use connectrum as a module. The changes I made cause it to more behave as it should by a module library (the user of the library decides how logging should be handled instead of the library itself).