### PR TITLE
An attempt at debugging get_port().

### DIFF
--- a/connectrum/client.py
+++ b/connectrum/client.py
@@ -145,7 +145,7 @@ class StratumClient:
             pointless traffic.
         '''
         while self.protocol:
-            vers = await self.RPC('server.version')
+            vers = await self.RPC('server.version', "connectrum", "1.1")
             logger.debug("Server version: " + vers)
             await asyncio.sleep(600)
 

--- a/connectrum/client.py
+++ b/connectrum/client.py
@@ -120,7 +120,7 @@ class StratumClient:
                 transport, protocol = await aiosocks.create_connection(
                                         StratumProtocol, proxy=proxy,
                                         proxy_auth=None,
-                                        remote_resolve=True, ssl=use_ssl,
+                                        remote_resolve=True, loop=self.loop, ssl=use_ssl,
                                         dst=(hostname, port))
             else:
                 logger.debug("Error: want to use proxy, but no aiosocks module.")

--- a/connectrum/client.py
+++ b/connectrum/client.py
@@ -164,7 +164,7 @@ class StratumClient:
 
         # subscriptions are a Q, normal requests are a future
         if is_subscribe:
-            waitQ = asyncio.Queue()
+            waitQ = asyncio.Queue(loop=self.loop)
             self.subscriptions[method].append(waitQ)
 
         fut = asyncio.Future(loop=self.loop)

--- a/connectrum/svr_info.py
+++ b/connectrum/svr_info.py
@@ -99,12 +99,12 @@ class ServerInfo(dict):
         '''
         assert len(for_protocol) == 1, "expect single letter code"
 
-        rv = [i[0] for i in self['ports'] if i[0] == for_protocol]
+        rv = [i for i in self['ports'] if i[0] == for_protocol]
 
         port = None
-        if len(rv) >= 2:
+        if len(rv) < 2:
             try:
-                port = int(rv[1:])
+                port = int(rv[0][1:])
             except:
                 pass
         port = port or DEFAULT_PORTS[for_protocol]


### PR DESCRIPTION
svr_info.get_port() Never seems to return anything
but the default ports for a given protocol code.
This change gets things working for me.

Should fix https://github.com/coinkite/connectrum/issues/7