### PR TITLE
Fix port handling

### DIFF
--- a/connectrum/svr_info.py
+++ b/connectrum/svr_info.py
@@ -99,7 +99,7 @@ class ServerInfo(dict):
         '''
         assert len(for_protocol) == 1, "expect single letter code"
 
-        rv = [i[0] for i in self['ports'] if i[0] == for_protocol]
+        rv = next(i for i in self['ports'] if i[0] == for_protocol)
 
         port = None
         if len(rv) >= 2:


### PR DESCRIPTION
For example, this wasn't working before this fix:

    PYTHONPATH=. python3 examples/cli.py --proto t --server testnet.qtornado.com --port 51001   blockchain.address.listunspent 2NEjeEtP5BJCNFUCDf3je5CQctKDnu8JHi6