### PR TITLE
fix keepalive

### DIFF
--- a/connectrum/client.py
+++ b/connectrum/client.py
@@ -146,7 +146,7 @@ class StratumClient:
         '''
         while self.protocol:
             vers = await self.RPC('server.version')
-            logger.debug("Server version: " + vers)
+            logger.debug("Server version: " + repr(vers))
             await asyncio.sleep(600)
 
 


### PR DESCRIPTION
vers can be a list, which can't be auto-converted to str for concatenation.